### PR TITLE
Add confirmation dialog to Surging Waters

### DIFF
--- a/src/SynergyToggle.lua
+++ b/src/SynergyToggle.lua
@@ -89,6 +89,10 @@ ST.outbreakCooldown = false
 ST.PURGESOUL = "/esoui/art/icons/achievement_murkmire_kill_voriplasm.dds"
 ST.blobBlock = false
 
+-- dsr
+ST.SURGINGWATERS = "/esoui/art/icons/death_recap_cold_aoe2.dds"
+ST.surgingWatersCooldown = false
+
 
 function ST.InitSavedVariables()
 	local defaults = {
@@ -98,6 +102,7 @@ function ST.InitSavedVariables()
 		general_conjurersPortal = false,
 		general_cloudrestPortalDebuff = true,
 		general_destructiveOutbreak = true,
+		general_surgingWaters = true,
 		general_arenaSigils = false,
 		dd_conduit = false,
 		dd_harvest = false,
@@ -379,6 +384,25 @@ function ST.BlockSynergies()
 					ST.ShowDialog("DestructiveOutbreak",
 						"|t35:35:/esoui/art/icons/ability_sorcerer_065.dds|t Destructive Outbreak",
 						"Are you sure you want to break free?\nPlease look after your mates.",
+						function()
+							SYNERGY:OnSynergyAbilityChanged()
+						end,
+						function()
+							SYNERGY:OnSynergyAbilityChanged()
+						end)
+					SHARED_INFORMATION_AREA:SetHidden(SYNERGY, true)
+					return true
+				end
+			end
+			if ST.savedVariables.general_surgingWaters and icon == ST.SURGINGWATERS then
+				if not ST.surgingWatersCooldown then
+					ST.surgingWatersCooldown = true
+					zo_callLater(function()
+						ST.surgingWatersCooldown = false
+					end, 10000)
+					ST.ShowDialog("Surging Waters",
+						"|t35:35:" .. ST.SURGINGWATERS .. "|t Surging Waters",
+						"Are you sure you want to go up? You won't be able to come back.",
 						function()
 							SYNERGY:OnSynergyAbilityChanged()
 						end,

--- a/src/SynergyToggleMenu.lua
+++ b/src/SynergyToggleMenu.lua
@@ -38,6 +38,13 @@ function ST.InitAddonMenu()
 	}
 	optionData[#optionData+1] = {
 		type = "checkbox",
+		name = "|t35:35:/esoui/art/icons/death_recap_cold_aoe2.dds|t Surging Waters (Dreadsail Reef)",
+		getFunc = function() return ST.savedVariables.general_surgingWaters end,
+		setFunc = function(value) ST.savedVariables.general_surgingWaters = value end,
+		tooltip = "Adds a confirmation you have to accept if you want to go up.",
+	}
+	optionData[#optionData+1] = {
+		type = "checkbox",
 		name = "|t35:35:/esoui/art/icons/collectible_memento_pearlsummon.dds|t Cloudrest Portal (Dont Portal Twice)",
 		getFunc = function() return ST.savedVariables.general_cloudrestPortalDebuff end,
 		setFunc = function(value) ST.savedVariables.general_cloudrestPortalDebuff = value end,


### PR DESCRIPTION
In DSR during the fight with the second boss, there's a synergy called "Surging Waters" that appears when Reef Heart was destroyed. Accidentally clicking it may lead to a wipe as the player may need to do the second reef right away.

Thus, adding the confirmation dialog, and copy-pasting the logic of the destructive outbreak in HRC.