### PR TITLE
Tweaks to MK, Alkosh, Coral, Atro & Blocking runebreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 07.10.2023
 - Tweaked Coral, Alkosh and MK modes conditions
 - Added blocking of Runebreak synergy
+- Storm Atronach synergy is also considered a blockable synergy for Alkosh due to the fact that it gives Major Berserk to the whole group
 -----------
+
 27.06.2023
 - New maintainer: helixanon
 - Added Martial Knowledge mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+07.10.2023
+- Tweaked Coral, Alkosh and MK modes conditions
+- Added blocking of Runebreak synergy
+-----------
 27.06.2023
 - New maintainer: helixanon
 - Added Martial Knowledge mode

--- a/ESOUI.md
+++ b/ESOUI.md
@@ -12,6 +12,8 @@ Disables orbs and templar shards while having more than 30% stamina.
 [SIZE="3"]Pure Agony synergy block[/SIZE]
 
 [SIZE="3"]DSR Surging waters synergy popup window (aka vHRC HM)[/SIZE]
+
+[SIZE="3"]Blocking Passage (Arcanist portal) and Runebreak synergies[/SIZE]
 [/COLOR]
 
 
@@ -25,11 +27,11 @@ Disables orbs and templar shards while having more than 30% stamina.
 - Prevent Destructive Outbreak (Adds a notification you have to accept to prevent unwanted explosions)
 - Prevent Surging Waters (Adds a notification you have to accept to prevent going up unwillingly)
 - Block Arena Sigils
-- Block Passage synergy (Arcanist portal)
 
 [*]Prevents synergy stealing
 - Options to disable Sorcerer Atros for tanks and healers
-- DDs can disable Conduit, Harvest, Grave, Shards, Lady Thorn, and Pure Agony
+- DDs can disable Conduit, Harvest, Grave, Shards, Lady Thorn, Pure Agony, and Runebreak
+- Block Passage synergy (Arcanist portal)
 
 [*]Blob Mode
 - Blocks the "Purge Soul" synergy for 2s and notifies you to move outside the group

--- a/src/SynergyToggle.lua
+++ b/src/SynergyToggle.lua
@@ -13,7 +13,7 @@ ST.SYNERGYBLACKLIST = {
 	["/esoui/art/icons/ability_necromancer_010_b.dds"] = true,
 	["/esoui/art/icons/ability_necromancer_004.dds"] = true,
 	["/esoui/art/icons/ability_sorcerer_lightning_splash.dds"] = true,
-    ["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = true,
+	["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = true,
 	["/esoui/art/icons/ability_warden_005_b.dds"] = true,
 	["/esoui/art/icons/ability_warden_007.dds"] = true,
 	["/esoui/art/icons/ability_templar_cleansing_ritual.dds"] = true,
@@ -32,7 +32,7 @@ ST.SYNERGYBLACKLIST = {
 	["/esoui/art/icons/ability_undaunted_001.dds"] = true,
 	["/esoui/art/icons/ability_u23_bloodball_chokeonit.dds"] = true,
 	["/esoui/art/icons/ability_arcanist_016_b.dds"] = true,
-    ["/esoui/art/icons/ability_arcanist_004.dds"] = true
+	["/esoui/art/icons/ability_arcanist_004.dds"] = true
 }
 
 ST.RESOURCESYNERGIES = {

--- a/src/SynergyToggle.lua
+++ b/src/SynergyToggle.lua
@@ -2,7 +2,7 @@ SynergyToggle = SynergyToggle or {}
 local ST = SynergyToggle
 
 ST.name = "SynergyToggle"
-ST.version = "1.11.0"
+ST.version = "1.12.0"
 
 ST.synergies = {}
 
@@ -13,6 +13,7 @@ ST.SYNERGYBLACKLIST = {
 	["/esoui/art/icons/ability_necromancer_010_b.dds"] = true,
 	["/esoui/art/icons/ability_necromancer_004.dds"] = true,
 	["/esoui/art/icons/ability_sorcerer_lightning_splash.dds"] = true,
+    ["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = true,
 	["/esoui/art/icons/ability_warden_005_b.dds"] = true,
 	["/esoui/art/icons/ability_warden_007.dds"] = true,
 	["/esoui/art/icons/ability_templar_cleansing_ritual.dds"] = true,
@@ -31,7 +32,6 @@ ST.SYNERGYBLACKLIST = {
 	["/esoui/art/icons/ability_undaunted_001.dds"] = true,
 	["/esoui/art/icons/ability_u23_bloodball_chokeonit.dds"] = true,
 	["/esoui/art/icons/ability_arcanist_016_b.dds"] = true,
-    ["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = true,
     ["/esoui/art/icons/ability_arcanist_004.dds"] = true
 }
 
@@ -454,7 +454,7 @@ function ST.BlockSynergies()
 				end
 			end
 			if not ST.HasLowStamina(20) then
-				if ST.savedVariables.tank_alkoshMode and ST.alkoshAvailable > 3 then
+				if ST.savedVariables.tank_alkoshMode and ST.alkoshAvailable >= 3 then
 					if ST.HasTargetAlkosh() or ST.alkoshAvailable < 5 then
 						if ST.SYNERGYBLACKLIST[icon] then
 							SHARED_INFORMATION_AREA:SetHidden(SYNERGY, true)

--- a/src/SynergyToggle.lua
+++ b/src/SynergyToggle.lua
@@ -31,6 +31,8 @@ ST.SYNERGYBLACKLIST = {
 	["/esoui/art/icons/ability_undaunted_001.dds"] = true,
 	["/esoui/art/icons/ability_u23_bloodball_chokeonit.dds"] = true,
 	["/esoui/art/icons/ability_arcanist_016_b.dds"] = true,
+    ["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = true,
+    ["/esoui/art/icons/ability_arcanist_004.dds"] = true
 }
 
 ST.RESOURCESYNERGIES = {
@@ -114,6 +116,7 @@ function ST.InitSavedVariables()
 		dd_shards = false,
 		dd_ritual = false,
 		dd_ladythorn = false,
+		dd_runebreak = false,
 		dd_bahseisMode = false,
 		dd_bahseisMode_magicka = 20,
 		dd_kinrasMode = false,
@@ -343,6 +346,7 @@ function ST.InitSynergies()
 	ST.synergies["/esoui/art/icons/ability_templar_sun_strike.dds"] = settings.dd_shards
 	ST.synergies["/esoui/art/icons/ability_templar_cleansing_ritual.dds"] = settings.dd_ritual
 	ST.synergies["/esoui/art/icons/ability_u23_bloodball_chokeonit.dds"] = settings.dd_ladythorn
+	ST.synergies["/esoui/art/icons/ability_arcanist_004.dds"] = settings.dd_runebreak
 	ST.synergies["/esoui/art/icons/ability_sorcerer_storm_atronach.dds"] = settings.tank_atronarch
 	ST.synergies["/esoui/art/icons/ability_nightblade_015.dds"] = settings.tank_nbshadowult
 	ST.synergies["/esoui/art/icons/collectible_memento_pearlsummon.dds"] = settings.healer_cloudrestPortalEntirely
@@ -433,7 +437,7 @@ function ST.BlockSynergies()
 			end
 			if not ST.HasLowStamina(ST.savedVariables.dd_coralriptideMode_stamina)
 				and ST.savedVariables.dd_coralriptideMode
-				and ST.coralriptideAvailable >= 5 then
+				and ST.coralriptideAvailable >= 3 then
 				
 				if ST.RESOURCESYNERGIES[icon] then
 					SHARED_INFORMATION_AREA:SetHidden(SYNERGY, true)
@@ -442,7 +446,7 @@ function ST.BlockSynergies()
 			end
 			if not ST.HasLowStamina(30)
 				and ST.savedVariables.dd_martialknowledgemode
-				and ST.mkavailable >= 5 then
+				and ST.mkavailable >= 3 then
 				
 				if ST.RESOURCESYNERGIES[icon] then
 					SHARED_INFORMATION_AREA:SetHidden(SYNERGY, true)
@@ -450,7 +454,7 @@ function ST.BlockSynergies()
 				end
 			end
 			if not ST.HasLowStamina(20) then
-				if ST.savedVariables.tank_alkoshMode and ST.alkoshAvailable > 0 then
+				if ST.savedVariables.tank_alkoshMode and ST.alkoshAvailable > 3 then
 					if ST.HasTargetAlkosh() or ST.alkoshAvailable < 5 then
 						if ST.SYNERGYBLACKLIST[icon] then
 							SHARED_INFORMATION_AREA:SetHidden(SYNERGY, true)

--- a/src/SynergyToggle.txt
+++ b/src/SynergyToggle.txt
@@ -1,6 +1,6 @@
 ## Title: Synergy Toggle
 ## Author: ownedbynico, helixanon
-## Version: 1.11.0
+## Version: 1.12.0
 ## Description: A collection of smart synergy options.
 ## APIVersion: 101037 101038
 ## DependsOn: LibAddonMenu-2.0

--- a/src/SynergyToggleMenu.lua
+++ b/src/SynergyToggleMenu.lua
@@ -158,6 +158,16 @@ function ST.InitAddonMenu()
 	}
 	optionData[#optionData+1] = {
 		type = "checkbox",
+		name = "|t35:35:/esoui/art/icons/ability_arcanist_004.dds|t Runebreak",
+		getFunc = function() return ST.savedVariables.dd_runebreak end,
+		setFunc = function(value)
+					ST.savedVariables.dd_runebreak = value
+					ST.synergies["/esoui/art/icons/ability_arcanist_004.dds"] = value
+				  end,
+		tooltip = "Blocks the Runebreak synergy.",
+	}
+	optionData[#optionData+1] = {
+		type = "checkbox",
 		name = "Lokkestiiz Mode",
 		getFunc = function() return ST.savedVariables.dd_lokkestiizMode end,
 		setFunc = function(value) ST.savedVariables.dd_lokkestiizMode = value end,


### PR DESCRIPTION
- Tweaked Coral, Alkosh and MK modes conditions
- Added blocking of Runebreak synergy
- Storm Atronach synergy is also considered a blockable synergy for Alkosh due to the fact that it gives Major Berserk to the whole group